### PR TITLE
fix: correction of csp in emg2023

### DIFF
--- a/src/mobisurvstd/emg2023/personnes.py
+++ b/src/mobisurvstd/emg2023/personnes.py
@@ -65,7 +65,7 @@ PCS_GROUP_CODE_MAP = {
     4: 5,  # EMG: Employés
     5: 6,  # EMG: Ouvriers
     6: 7,  # EMG: Retraité ou pré-retraité
-    7: None,  # EMG: Étudiant ou lycée
+    7: 8,  # EMG: Étudiant ou lycée
     8: 8,  # Au chômage ou en inactivité)
 }
 


### PR DESCRIPTION
This PR corrects the CSP for EMG 2023.
- Students (7 in EMG) should enter Others (8 officially)

However, when validating this change I noticed that there are other differences between the weighting of the EMG (at least the way we treat it) and the census data. I'm checking this with IPR right now, but I wanted to already open the PR to alert potential users.

<img width="1598" height="915" alt="image" src="https://github.com/user-attachments/assets/57240421-70b7-4d88-af19-d738bc5f1faa" />